### PR TITLE
Fix dataset availability start year in markdown cell

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,6 +45,6 @@ keywords:
   - unet
   - deep learning
 license: MIT
-commit: "4c541eb"
-version: "1.0.0"
-date-released: "2024-06-26"
+commit: "63b7376"
+version: "1.0.1"
+date-released: "2024-07-03"

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -137,9 +137,11 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "import os\n",
     "import warnings\n",
@@ -160,9 +162,7 @@
     "logging.getLogger('icenet').setLevel(logging.INFO)\n",
     "logging.getLogger('dask').setLevel(logging.ERROR)\n",
     "logging.getLogger('distributed').setLevel(logging.ERROR)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -173,22 +173,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from icenet.data.sic.mask import Masks\n",
     "from icenet.data.sic.osisaf import SICDownloader"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%env PYTHONWARNINGS=ignore"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -217,13 +217,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "masks = Masks(north=False, south=True)\n",
     "masks.generate(save_polarhole_masks=False)"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -413,7 +413,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "sic = SICDownloader(\n",
     "    dates=[\n",
@@ -427,9 +429,7 @@
     ")\n",
     "\n",
     "sic.download()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -480,7 +480,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "processing_dates = dict(\n",
     "    train=[pd.to_datetime(el) for el in pd.date_range(\"2020-01-01\", \"2020-01-04\")],\n",
@@ -488,9 +490,7 @@
     "    test=[pd.to_datetime(el) for el in pd.date_range(\"2020-04-01\", \"2020-04-02\")],\n",
     ")\n",
     "processed_name = \"notebook_api_data\""
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -508,18 +508,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from icenet.data.processors.era5 import IceNetERA5PreProcessor # Unused in this demonstrator notebook\n",
     "from icenet.data.processors.meta import IceNetMetaPreProcessor\n",
     "from icenet.data.processors.osi import IceNetOSIPreProcessor"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "osi = IceNetOSIPreProcessor(\n",
     "    [\"siconca\"],                # Absolute normalised variables\n",
@@ -538,9 +540,7 @@
     "    north=False,\n",
     "    south=True,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -574,7 +574,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "osi.init_source_data(\n",
     "    lag_days=1,\n",
@@ -582,9 +584,7 @@
     "osi.process()\n",
     "\n",
     "meta.process()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -604,7 +604,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from icenet.data.loaders import IceNetDataLoaderFactory\n",
     "\n",
@@ -624,9 +626,7 @@
     "    output_batch_size=1,\n",
     "    generate_workers=1\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -637,12 +637,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "dl._config"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -653,13 +653,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%%time\n",
     "dl.generate()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -670,23 +670,23 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "x, y, sw = dl.generate_sample(pd.Timestamp(\"2020-04-01\"))"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "print(f\"type(x): {type(x)}, x.shape: {x.shape}\")\n",
     "print(f\"type(y): {type(y)}, y.shape: {y.shape}\")\n",
     "print(f\"type(sw): {type(sw)}, sw.shape: {sw.shape}\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -707,16 +707,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from icenet.data.dataset import IceNetDataSet\n",
     "\n",
     "dataset_config = f\"dataset_config.{dataset_name}.json\"\n",
     "dataset = IceNetDataSet(dataset_config, batch_size=1)\n",
     "strategy = tf.distribute.get_strategy()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -727,12 +727,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "dataset._config"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -743,12 +743,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "dataset.get_data_loader()"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -759,7 +759,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%%time\n",
     "from icenet.model.train import train_model\n",
@@ -777,9 +779,7 @@
     "    training_verbosity=2,\n",
     "    workers=1\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -802,7 +802,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "%%time\n",
     "from icenet.model.predict import predict_forecast\n",
@@ -822,9 +824,7 @@
     "                 for el in pd.date_range(\"2020-04-01\", \"2020-04-02\")],\n",
     "    test_set=True,\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -848,21 +848,21 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "!printf \"2020-04-01\\n2020-04-02\" | tee predict_dates.csv"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "!icenet_output -m -o ./results/predict custom_run_forecast api_dataset predict_dates.csv"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -892,7 +892,9 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from icenet.plotting.video import xarray_to_video as xvid\n",
     "from icenet.data.sic.mask import Masks\n",
@@ -925,9 +927,7 @@
     "\n",
     "    anim = xvid(fc, 15, figsize=4, mask=land_mask, colorbar_label=\"Sea-ice concentration fraction\")\n",
     "    display(HTML(anim.to_jshtml()))"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -942,12 +942,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "plot_result(\"results/predict/custom_run_forecast.nc\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1010,12 +1010,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "plot_result(\"results/predict/good_forecast.nc\")"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1036,7 +1036,7 @@
     "\n",
     "For the training model generated, the accuracy of the results depends on the data used as training inputs (in this demonstrator notebook, only a limited subset of the OSI SAF SIC data is used due to resource limitations on Binder).\n",
     "\n",
-    "On less resource constricted systems, as elucidated above, it is possible to use other data downloaders that include variables which relate to sea ice formation to improve prediction results while including a larger date range as available from the different data sources. For day to day forecast generation, a subset of the OSI SAF (1940-present) and ERA5 datasets (1979-present) are utilised for training.\n",
+    "On less resource constricted systems, as elucidated above, it is possible to use other data downloaders that include variables which relate to sea ice formation to improve prediction results while including a larger date range as available from the different data sources. For day to day forecast generation, a subset of the OSI SAF (1978-present) and ERA5 datasets (1940-present) are utilised for training.\n",
     "\n",
     "For more details, the [original paper](https://www.nature.com/articles/s41467-021-25257-4) is a recommended read. A more up-to-date paper considering the latest IceNet implementation changes since the publication of the original paper is currently in progress."
    ]
@@ -1072,26 +1072,26 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "import icenet\n",
     "icenet_version = icenet.__version__\n",
     "print(f'IceNet version: {icenet_version}')"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
    "source": [
     "from datetime import date\n",
     "print(f'Last tested: {date.today()}')"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fix the start year of OSI SAF and ERA5 of available datasets being swapped around in markdown explanation section.